### PR TITLE
Restore bugfix for first message style

### DIFF
--- a/nexus-tweaks.user.js
+++ b/nexus-tweaks.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        AnneTrue's Nexus Tweaks
-// @version     1.3.0
+// @version     1.3.1
 // @description Tweaks for Nexus Clash's UI
 // @namespace   https://github.com/AnneTrue/
 // @author      Anne True
@@ -42,7 +42,7 @@ promiseList.push((async () => {
     'Adds styling to the message history to improve ease of reading. Includes combat actions, searches, speech, and more. Runs in both in-game and the character profile\'s week log',
   );
 
-  const pfx = '^- (?:\\(\\d+ times\\) )?'; // message prefix
+  const pfx = '^[ ]?- (?:\\(\\d+ times\\) )?'; // message prefix
   const globalMatches = [
     { // fix the a(n) text based on vowels
       msg: /( a)(\((n)\)( [AEIOUaeiou])|\(n\)( [^AEIOUaeiou]))/g,

--- a/scaffolding.user.js
+++ b/scaffolding.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        AnneTrue's Nexus Tweaks Scaffolding
-// @version     1.3.0
+// @version     1.3.1
 // @description Scaffolding and API for nexus-tweaks
 // @namespace   https://github.com/AnneTrue/
 // @author      Anne True


### PR DESCRIPTION
The fix for the first message having an extra " "
character in it was dropped during commits.
This change restores the fix.