### PR TITLE
char list: fix 0mp display

### DIFF
--- a/nexus-tweaks.user.js
+++ b/nexus-tweaks.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        AnneTrue's Nexus Tweaks
-// @version     1.6.1
+// @version     1.6.2
 // @description Tweaks for Nexus Clash's UI
 // @namespace   https://github.com/AnneTrue/
 // @author      Anne True
@@ -325,7 +325,7 @@ promiseList.push((async () => {
       if (round9to10 && value % 10 === 9) {
         effectiveValue++;
       }
-      return effectiveValue + Math.floor((effectiveValue-1)/10);
+      return effectiveValue + Math.max(0, Math.floor((effectiveValue-1)/10));
     };
     const previousHpOffset = getPixelOffset(person.previousHp);
     const currentHpOffset = getPixelOffset(person.currentHp);

--- a/scaffolding.user.js
+++ b/scaffolding.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        AnneTrue's Nexus Tweaks Scaffolding
-// @version     1.6.1
+// @version     1.6.2
 // @description Scaffolding and API for nexus-tweaks
 // @namespace   https://github.com/AnneTrue/
 // @author      Anne True


### PR DESCRIPTION
The MP bar defaults to 20px width for a 0mp target because the code for the separator bars generated an illegal -1 width in the style. Reported by Ferris