### PR TITLE
Module: Lich Pet Summon fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Shows a proportional health and magic bar when the appropriate skills are availa
 Characters taking damage since the last refresh will show a corresponding health bar animation to quickly notice combat actions in the area.
 Characters entering or reentering a location will be labeled with a "NEW" status tag to more easily notice them within a highly populated area.
 
+## Lich Pet Summon fix
+A local module that rearranges Necro/FM summoning buttons into a second row under Skeleton/Zombie summoning buttons. No more wide Pet tables.
+
 # Contributing
 ## Guidelines
 Feel free to send pull requests with fixes or new features, open Github issues, comment on the Nexus forum thread with ideas, contact AnneTrue on discord, and more.

--- a/nexus-tweaks.user.js
+++ b/nexus-tweaks.user.js
@@ -1161,19 +1161,21 @@ promiseList.push((async () => {
 
     // Pets summon buttons
     const petSummons = petTableTable.querySelector('tbody').querySelector('table.summonsButtons>tbody');
-    const FM = petSummons.querySelector('input[value="Fossil Monstrosity"]');
+    const fossilMonstrosity = petSummons.querySelector('input[value="Fossil Monstrosity"]');
     const necro = petSummons.querySelector('input[value="Necrophage"]');
 
-    if (FM) {
+    if (fossilMonstrosity) {
       // This is how they currently display by default
-      // FM.nextSibling.value = 'Fossil Monstrosity (3 Skeletons) '
+      // fossilMonstrosity.nextSibling.value = 'Fossil Monstrosity (3 Skeletons) '
       if (petSummons.children.length < 3) petSummons.appendChild(document.createElement('tr'));
-      petSummons.children[2].insertBefore(FM.parentNode.parentNode, petSummons.children[2].firstChild);
+      // Second row on the summoning panel, below Skeletons et al
+      petSummons.children[2].insertBefore(fossilMonstrosity.parentNode.parentNode, petSummons.children[2].firstChild);
     }
     if (necro) {
       // This is how they currently display by default
       // necro.nextSibling.value = 'Necrophage (3 Zombies/Ghouls) '
       if (petSummons.children.length < 3) petSummons.appendChild(document.createElement('tr'));
+      // Second row on the summoning panel, below Skeletons et al
       petSummons.children[2].appendChild(necro.parentNode.parentNode);
     }
   }

--- a/nexus-tweaks.user.js
+++ b/nexus-tweaks.user.js
@@ -1165,12 +1165,16 @@ promiseList.push((async () => {
     const necro = petSummons.querySelector('input[value="Necrophage"]');
 
     if (FM) {
-      FM.nextSibling.value = 'Fossil Monstrosity (3 Skeletons) '
+      // This is how they currently display by default
+      // FM.nextSibling.value = 'Fossil Monstrosity (3 Skeletons) '
       if (petSummons.children.length < 3) petSummons.appendChild(document.createElement('tr'));
       petSummons.children[2].insertBefore(FM.parentNode.parentNode, petSummons.children[2].firstChild);
     }
     if (necro) {
-      necro.nextSibling.value = 'Necrophage (3 Zombies/Ghouls) ';
+      // This is how they currently display by default
+      // necro.nextSibling.value = 'Necrophage (3 Zombies/Ghouls) '
+      if (petSummons.children.length < 3) petSummons.appendChild(document.createElement('tr'));
+      petSummons.children[2].appendChild(necro.parentNode.parentNode);
     }
   }
 

--- a/nexus-tweaks.user.js
+++ b/nexus-tweaks.user.js
@@ -1145,6 +1145,45 @@ promiseList.push((async () => {
 
 
 //##############################################################################
+promiseList.push((async () => {
+  const mod = await nexusTweaks.registerModule(
+    'lichDelight',
+    'Lich Pet Summon fix',
+    'local',
+    'Fixes the UI for summoning lich pets. Should make the pet list more eye-friendly.',
+  );
+
+  const lichDelight = () => {
+    'use strict';
+
+    const petTableTable = document.querySelector('.petTable');
+    if (!petTableTable) {
+      return;
+    }
+
+    // Pets summon buttons
+    const petSummons = petTableTable.querySelector('tbody').querySelector('table.summonsButtons>tbody');
+    const FM = petSummons.querySelector('input[value="Fossil Monstrosity"]');
+    const necro = petSummons.querySelector('input[value="Necrophage"]');
+
+    if (FM) {
+      FM.nextSibling.value = 'Fossil Monstrosity (3 Skeletons) '
+      if (petSummons.children.length < 3) petSummons.appendChild(document.createElement('tr'));
+      petSummons.children[2].insertBefore(FM.parentNode.parentNode, petSummons.children[2].firstChild);
+    }
+    if (necro) {
+      necro.nextSibling.value = 'Necrophage (3 Zombies/Ghouls) '
+    }
+  }
+
+  await mod.registerMethod(
+    'sync',
+    lichDelight
+  );
+})());
+
+
+//##############################################################################
 // Must be last executed step, as this unlocks nexusTweaks to run
 (async () => {
   nexusTweaks.addGlobalStyle(await GM.getResourceUrl('nexusTweaksCSS'));

--- a/nexus-tweaks.user.js
+++ b/nexus-tweaks.user.js
@@ -1157,9 +1157,7 @@ promiseList.push((async () => {
     'use strict';
 
     const petTableTable = document.querySelector('.petTable');
-    if (!petTableTable) {
-      return;
-    }
+    if (!petTableTable) return;
 
     // Pets summon buttons
     const petSummons = petTableTable.querySelector('tbody').querySelector('table.summonsButtons>tbody');
@@ -1172,7 +1170,7 @@ promiseList.push((async () => {
       petSummons.children[2].insertBefore(FM.parentNode.parentNode, petSummons.children[2].firstChild);
     }
     if (necro) {
-      necro.nextSibling.value = 'Necrophage (3 Zombies/Ghouls) '
+      necro.nextSibling.value = 'Necrophage (3 Zombies/Ghouls) ';
     }
   }
 


### PR DESCRIPTION
Makes the overly wide petlist for liches with summon zombie+skeleton+FM+necro more eye-friendly.

Goes from this
![Screenshot_3](https://user-images.githubusercontent.com/75849479/153099857-9e86fdeb-fee2-4467-af87-6da6062259fb.jpg)
To this
![Screenshot_4](https://user-images.githubusercontent.com/75849479/153099870-ea38ab3c-5334-4553-8b35-08159be3405c.jpg)

